### PR TITLE
Move to own org

### DIFF
--- a/001_go_modules_tour/README.md
+++ b/001_go_modules_tour/README.md
@@ -732,29 +732,29 @@ fork github.com/rsc/quote and then push your change to your fork.
 
 ```
 $ cd ../quote
-$ git remote add $GITHUB_USERNAME https://github.com/$GITHUB_USERNAME/go-modules-by-example-quote-fork
+$ git remote add $GITHUB_ORG https://github.com/$GITHUB_ORG/quote-fork
 $ git commit -a -m 'my fork'
-[my_quote ac67d49] my fork
+[my_quote 86b72ac] my fork
  1 file changed, 1 insertion(+), 1 deletion(-)
-$ git push -q $GITHUB_USERNAME
+$ git push -q $GITHUB_ORG
 remote: 
 remote: Create a pull request for 'my_quote' on GitHub by visiting:        
-remote:      https://github.com/myitcv/go-modules-by-example-quote-fork/pull/new/my_quote        
+remote:      https://github.com/go-modules-by-example/quote-fork/pull/new/my_quote        
 remote: 
 $ git tag v0.0.0-myfork
-$ git push -q $GITHUB_USERNAME v0.0.0-myfork
+$ git push -q $GITHUB_ORG v0.0.0-myfork
 ```
 
 Then you can use that as the replacement:
 
 ```
 $ cd ../hello
-$ go mod edit -replace=rsc.io/quote=github.com/$GITHUB_USERNAME/go-modules-by-example-quote-fork@v0.0.0-myfork
+$ go mod edit -replace=rsc.io/quote=github.com/$GITHUB_ORG/quote-fork@v0.0.0-myfork
 $ go list -m
-go: finding github.com/myitcv/go-modules-by-example-quote-fork v0.0.0-myfork
+go: finding github.com/go-modules-by-example/quote-fork v0.0.0-myfork
 github.com/you/hello
 $ go build
-go: downloading github.com/myitcv/go-modules-by-example-quote-fork v0.0.0-myfork
+go: downloading github.com/go-modules-by-example/quote-fork v0.0.0-myfork
 $ LANG=fr ./hello
 Je peux manger du verre, ça ne me fait pas mal.
 ```

--- a/001_go_modules_tour/script.sh
+++ b/001_go_modules_tour/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME
@@ -179,20 +156,21 @@ go build
 
 # ensure repo exists and clean up any existing tag
 now=$(date +'%Y%m%d%H%M%S_%N')
-githubcli repo renameIfExists go-modules-by-example-quote-fork go-modules-by-example-quote-fork_$now
-githubcli repo create go-modules-by-example-quote-fork
+githubcli repo renameIfExists $GITHUB_ORG/quote-fork quote-fork_$now
+githubcli repo transfer $GITHUB_ORG/quote-fork_$now $GITHUB_ORG_ARCHIVE
+githubcli repo create $GITHUB_ORG/quote-fork
 
 # block: setup our quote
 cd ../quote
-git remote add $GITHUB_USERNAME https://github.com/$GITHUB_USERNAME/go-modules-by-example-quote-fork
+git remote add $GITHUB_ORG https://github.com/$GITHUB_ORG/quote-fork
 git commit -a -m 'my fork'
-git push -q $GITHUB_USERNAME
+git push -q $GITHUB_ORG
 git tag v0.0.0-myfork
-git push -q $GITHUB_USERNAME v0.0.0-myfork
+git push -q $GITHUB_ORG v0.0.0-myfork
 
 # block: use our quote
 cd ../hello
-go mod edit -replace=rsc.io/quote=github.com/$GITHUB_USERNAME/go-modules-by-example-quote-fork@v0.0.0-myfork
+go mod edit -replace=rsc.io/quote=github.com/$GITHUB_ORG/quote-fork@v0.0.0-myfork
 go list -m
 go build
 LANG=fr ./hello

--- a/002_using_gopkg_in/script.sh
+++ b/002_using_gopkg_in/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME

--- a/003_migrate_buffalo/script.sh
+++ b/003_migrate_buffalo/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 # block: pinned commits

--- a/004_echo_example/README.md
+++ b/004_echo_example/README.md
@@ -130,18 +130,18 @@ go: finding github.com/labstack/echo v3.2.1
 go: downloading github.com/labstack/echo v3.2.1+incompatible
 go: finding github.com/labstack/gommon/log latest
 go: finding github.com/labstack/gommon/color latest
-go: finding github.com/labstack/gommon v0.2.7
-go: downloading github.com/labstack/gommon v0.2.7
 go: finding golang.org/x/crypto/acme/autocert latest
 go: finding golang.org/x/crypto/acme latest
 go: finding golang.org/x/crypto latest
-go: downloading golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b
-go: finding github.com/mattn/go-isatty v0.0.4
+go: downloading golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4
+go: finding github.com/labstack/gommon v0.2.7
+go: downloading github.com/labstack/gommon v0.2.7
 go: finding github.com/valyala/fasttemplate latest
 go: finding github.com/mattn/go-colorable v0.0.9
+go: finding github.com/mattn/go-isatty v0.0.4
 go: downloading github.com/mattn/go-colorable v0.0.9
-go: downloading github.com/mattn/go-isatty v0.0.4
 go: downloading github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4
+go: downloading github.com/mattn/go-isatty v0.0.4
 go: finding github.com/valyala/bytebufferpool v1.0.0
 go: downloading github.com/valyala/bytebufferpool v1.0.0
 ```
@@ -166,7 +166,7 @@ require (
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
-	golang.org/x/crypto v0.0.0-20180910181607-0e37d006457b // indirect
+	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 // indirect
 )
 ```
 

--- a/004_echo_example/script.sh
+++ b/004_echo_example/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME

--- a/005_old_go/README.md
+++ b/005_old_go/README.md
@@ -70,12 +70,12 @@ $ cd hello
 $ cat <<EOD >hello.go
 package example
 
-import "github.com/myitcv/go-modules-by-example-v2-module/v2/goodbye"
+import "github.com/$GITHUB_ORG/v2-module/v2/goodbye"
 
 const Name = goodbye.Name
 EOD
 $ cat <<EOD >go.mod
-module github.com/myitcv/go-modules-by-example-v2-module/v2
+module github.com/$GITHUB_ORG/v2-module/v2
 EOD
 $ mkdir goodbye
 $ cat <<EOD >goodbye/goodbye.go
@@ -84,28 +84,28 @@ package goodbye
 const Name = "Goodbye"
 EOD
 $ go test ./...
-?   	github.com/myitcv/go-modules-by-example-v2-module/v2	[no test files]
-?   	github.com/myitcv/go-modules-by-example-v2-module/v2/goodbye	[no test files]
+?   	github.com/go-modules-by-example/v2-module/v2	[no test files]
+?   	github.com/go-modules-by-example/v2-module/v2/goodbye	[no test files]
 $ git init
 Initialized empty Git repository in /root/hello/.git/
 $ git add -A
 $ git commit -m 'Initial commit'
-[master (root-commit) c5a3321] Initial commit
+[master (root-commit) 5c02002] Initial commit
  3 files changed, 9 insertions(+)
  create mode 100644 go.mod
  create mode 100644 goodbye/goodbye.go
  create mode 100644 hello.go
-$ git remote add origin https://github.com/myitcv/go-modules-by-example-v2-module
+$ git remote add origin https://github.com/$GITHUB_ORG/v2-module
 $ git push origin master
 remote: 
 remote: Create a pull request for 'master' on GitHub by visiting:        
-remote:      https://github.com/myitcv/go-modules-by-example-v2-module/pull/new/master        
+remote:      https://github.com/go-modules-by-example/v2-module/pull/new/master        
 remote: 
-To https://github.com/myitcv/go-modules-by-example-v2-module
+To https://github.com/go-modules-by-example/v2-module
  * [new branch]      master -> master
 $ git tag v2.0.0
 $ git push origin v2.0.0
-To https://github.com/myitcv/go-modules-by-example-v2-module
+To https://github.com/go-modules-by-example/v2-module
  * [new tag]         v2.0.0 -> v2.0.0
 ```
 
@@ -120,7 +120,7 @@ $ cat <<EOD >main.go
 package main
 
 import "fmt"
-import "github.com/myitcv/go-modules-by-example-v2-module/v2"
+import "github.com/$GITHUB_ORG/v2-module/v2"
 
 func main() {
 	fmt.Println(example.Name)
@@ -129,8 +129,8 @@ EOD
 $ go mod init example.com/usehello
 go: creating new go.mod: module example.com/usehello
 $ go build
-go: finding github.com/myitcv/go-modules-by-example-v2-module/v2 v2.0.0
-go: downloading github.com/myitcv/go-modules-by-example-v2-module/v2 v2.0.0
+go: finding github.com/go-modules-by-example/v2-module/v2 v2.0.0
+go: downloading github.com/go-modules-by-example/v2-module/v2 v2.0.0
 $ ./usehello
 Goodbye
 ```
@@ -146,13 +146,13 @@ $ cat <<EOD >main.go
 package main
 
 import "fmt"
-import "github.com/myitcv/go-modules-by-example-v2-module"
+import "github.com/$GITHUB_ORG/v2-module"
 
 func main() {
 	fmt.Println(example.Name)
 }
 EOD
-$ PATH=/tmp/go/bin:$PATH go get github.com/myitcv/go-modules-by-example-v2-module
+$ PATH=/tmp/go/bin:$PATH go get github.com/$GITHUB_ORG/v2-module
 $ PATH=/tmp/go/bin:$PATH go build
 $ ./hello
 Goodbye

--- a/005_old_go/script.sh
+++ b/005_old_go/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME
@@ -42,8 +19,9 @@ PATH=/tmp/go/bin:$PATH go version
 
 # ensure repo exists and clean up any existing tag
 now=$(date +'%Y%m%d%H%M%S_%N')
-githubcli repo renameIfExists go-modules-by-example-v2-module go-modules-by-example-v2-module_$now
-githubcli repo create go-modules-by-example-v2-module
+githubcli repo renameIfExists $GITHUB_ORG/v2-module v2-module_$now
+githubcli repo transfer $GITHUB_ORG/v2-module_$now $GITHUB_ORG_ARCHIVE
+githubcli repo create $GITHUB_ORG/v2-module
 
 # block: create go module v2
 cd $HOME
@@ -52,12 +30,12 @@ cd hello
 cat <<EOD > hello.go
 package example
 
-import "github.com/myitcv/go-modules-by-example-v2-module/v2/goodbye"
+import "github.com/$GITHUB_ORG/v2-module/v2/goodbye"
 
 const Name = goodbye.Name
 EOD
 cat <<EOD > go.mod
-module github.com/myitcv/go-modules-by-example-v2-module/v2
+module github.com/$GITHUB_ORG/v2-module/v2
 EOD
 mkdir goodbye
 cat <<EOD > goodbye/goodbye.go
@@ -69,7 +47,7 @@ go test ./...
 git init
 git add -A
 git commit -m 'Initial commit'
-git remote add origin https://github.com/myitcv/go-modules-by-example-v2-module
+git remote add origin https://github.com/$GITHUB_ORG/v2-module
 git push origin master
 git tag v2.0.0
 git push origin v2.0.0
@@ -82,7 +60,7 @@ cat <<EOD > main.go
 package main
 
 import "fmt"
-import "github.com/myitcv/go-modules-by-example-v2-module/v2"
+import "github.com/$GITHUB_ORG/v2-module/v2"
 
 func main() {
 	fmt.Println(example.Name)
@@ -100,13 +78,13 @@ cat <<EOD > main.go
 package main
 
 import "fmt"
-import "github.com/myitcv/go-modules-by-example-v2-module"
+import "github.com/$GITHUB_ORG/v2-module"
 
 func main() {
 	fmt.Println(example.Name)
 }
 EOD
-PATH=/tmp/go/bin:$PATH go get github.com/myitcv/go-modules-by-example-v2-module
+PATH=/tmp/go/bin:$PATH go get github.com/$GITHUB_ORG/v2-module
 PATH=/tmp/go/bin:$PATH go build
 ./hello
 

--- a/006_not_yet_go_module/script.sh
+++ b/006_not_yet_go_module/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME

--- a/007_old_code_replace/script.sh
+++ b/007_old_code_replace/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME

--- a/008_vendor_example/script.sh
+++ b/008_vendor_example/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME

--- a/009_submodules/README.md
+++ b/009_submodules/README.md
@@ -77,23 +77,23 @@ Initialise a directory as a git repo, and add an appropriate remote:
 
 
 ```
-$ mkdir go-modules-by-example-submodules
-$ cd go-modules-by-example-submodules
+$ mkdir submodules
+$ cd submodules
 $ git init -q
-$ git remote add origin https://github.com/$GITHUB_USERNAME/go-modules-by-example-submodules
+$ git remote add origin https://github.com/$GITHUB_ORG/submodules
 ```
 
 Define a root module, at the root of the repo, commit and push:
 
 ```
-$ go mod init github.com/$GITHUB_USERNAME/go-modules-by-example-submodules
-go: creating new go.mod: module github.com/myitcv/go-modules-by-example-submodules
+$ go mod init github.com/$GITHUB_ORG/submodules
+go: creating new go.mod: module github.com/go-modules-by-example/submodules
 $ git add go.mod
 $ git commit -q -am 'Initial commit'
 $ git push -q
 remote: 
 remote: Create a pull request for 'master' on GitHub by visiting:        
-remote:      https://github.com/myitcv/go-modules-by-example-submodules/pull/new/master        
+remote:      https://github.com/go-modules-by-example/submodules/pull/new/master        
 remote: 
 ```
 
@@ -107,10 +107,10 @@ package b
 
 const Name = "Gopher"
 EOD
-$ go mod init github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/b
-go: creating new go.mod: module github.com/myitcv/go-modules-by-example-submodules/b
+$ go mod init github.com/$GITHUB_ORG/submodules/b
+go: creating new go.mod: module github.com/go-modules-by-example/submodules/b
 $ go test
-?   	github.com/myitcv/go-modules-by-example-submodules/b	[no test files]
+?   	github.com/go-modules-by-example/submodules/b	[no test files]
 ```
 
 Commit, tag and push our new package:
@@ -136,7 +136,7 @@ $ cat <<EOD >a.go
 package main
 
 import (
-	"github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/b"
+	"github.com/$GITHUB_ORG/submodules/b"
 	"fmt"
 )
 
@@ -146,19 +146,19 @@ func main() {
 	fmt.Println(Name)
 }
 EOD
-$ go mod init github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/a
-go: creating new go.mod: module github.com/myitcv/go-modules-by-example-submodules/a
+$ go mod init github.com/$GITHUB_ORG/submodules/a
+go: creating new go.mod: module github.com/go-modules-by-example/submodules/a
 ```
 
 Build and run that main package:
 
 ```
 $ go run .
-go: finding github.com/myitcv/go-modules-by-example-submodules/b v0.1.1
-go: downloading github.com/myitcv/go-modules-by-example-submodules/b v0.1.1
+go: finding github.com/go-modules-by-example/submodules/b v0.1.1
+go: downloading github.com/go-modules-by-example/submodules/b v0.1.1
 Gopher
-$ go list -m github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/b
-github.com/myitcv/go-modules-by-example-submodules/b v0.1.1
+$ go list -m github.com/$GITHUB_ORG/submodules/b
+github.com/go-modules-by-example/submodules/b v0.1.1
 ```
 
 Notice how we resolve to the tagged version of `package b`.
@@ -184,9 +184,9 @@ $ export GOBIN=$PWD/.bin
 $ export PATH=$GOBIN:$PATH
 $ go mod init example.com/blah
 go: creating new go.mod: module example.com/blah
-$ go get github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/a@v1.0.0
-go: finding github.com/myitcv/go-modules-by-example-submodules/a v1.0.0
-go: downloading github.com/myitcv/go-modules-by-example-submodules/a v1.0.0
+$ go get github.com/$GITHUB_ORG/submodules/a@v1.0.0
+go: finding github.com/go-modules-by-example/submodules/a v1.0.0
+go: downloading github.com/go-modules-by-example/submodules/a v1.0.0
 $ a
 Gopher
 ```

--- a/009_submodules/script.sh
+++ b/009_submodules/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME
@@ -37,17 +14,18 @@ git config --global push.default current
 
 # tidy up if we already have the repo
 now=$(date +'%Y%m%d%H%M%S_%N')
-githubcli repo renameIfExists go-modules-by-example-submodules go-modules-by-example-submodules_$now
-githubcli repo create go-modules-by-example-submodules
+githubcli repo renameIfExists $GITHUB_ORG/submodules submodules_$now
+githubcli repo transfer $GITHUB_ORG/submodules_$now $GITHUB_ORG_ARCHIVE
+githubcli repo create $GITHUB_ORG/submodules
 
 # block: setup
-mkdir go-modules-by-example-submodules
-cd go-modules-by-example-submodules
+mkdir submodules
+cd submodules
 git init -q
-git remote add origin https://github.com/$GITHUB_USERNAME/go-modules-by-example-submodules
+git remote add origin https://github.com/$GITHUB_ORG/submodules
 
 # block: define repo root module
-go mod init github.com/$GITHUB_USERNAME/go-modules-by-example-submodules
+go mod init github.com/$GITHUB_ORG/submodules
 git add go.mod
 git commit -q -am 'Initial commit'
 git push -q
@@ -60,7 +38,7 @@ package b
 
 const Name = "Gopher"
 EOD
-go mod init github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/b
+go mod init github.com/$GITHUB_ORG/submodules/b
 go test
 
 # block: commit and tag b
@@ -81,7 +59,7 @@ cat <<EOD > a.go
 package main
 
 import (
-	"github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/b"
+	"github.com/$GITHUB_ORG/submodules/b"
 	"fmt"
 )
 
@@ -91,11 +69,11 @@ func main() {
 	fmt.Println(Name)
 }
 EOD
-go mod init github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/a
+go mod init github.com/$GITHUB_ORG/submodules/a
 
 # block: run package a
 go run .
-go list -m github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/b
+go list -m github.com/$GITHUB_ORG/submodules/b
 
 # block: commit and tag a
 cd ..
@@ -110,7 +88,7 @@ cd $(mktemp -d)
 export GOBIN=$PWD/.bin
 export PATH=$GOBIN:$PATH
 go mod init example.com/blah
-go get github.com/$GITHUB_USERNAME/go-modules-by-example-submodules/a@v1.0.0
+go get github.com/$GITHUB_ORG/submodules/a@v1.0.0
 a
 
 # block: version details

--- a/010_tools/README.md
+++ b/010_tools/README.md
@@ -83,8 +83,8 @@ First, ceate an example module. This example will require
 [`stringer`](https://godoc.org/golang.org/x/tools/cmd/stringer) to help with code generation.
 
 ```
-$ mkdir /tmp/go-modules-by-example-tools
-$ cd /tmp/go-modules-by-example-tools
+$ mkdir /tmp/tools
+$ cd /tmp/tools
 $ go mod init example.com/blah/painkiller
 go: creating new go.mod: module example.com/blah/painkiller
 ```
@@ -121,7 +121,7 @@ $ go install golang.org/x/tools/cmd/stringer
 go: finding golang.org/x/tools/cmd/stringer latest
 go: finding golang.org/x/tools/cmd latest
 go: finding golang.org/x/tools latest
-go: downloading golang.org/x/tools v0.0.0-20180927044812-b14f328a6211
+go: downloading golang.org/x/tools v0.0.0-20181006002542-f60d9635b16a
 ```
 
 The module reflects the dependency:
@@ -135,7 +135,7 @@ $ go mod edit -json
 	"Require": [
 		{
 			"Path": "golang.org/x/tools",
-			"Version": "v0.0.0-20180927044812-b14f328a6211",
+			"Version": "v0.0.0-20181006002542-f60d9635b16a",
 			"Indirect": true
 		}
 	],
@@ -149,7 +149,7 @@ $ go mod edit -json
 
 ```
 $ which stringer
-/tmp/go-modules-by-example-tools/bin/stringer
+/tmp/tools/bin/stringer
 ```
 
 Let's use `stringer` via a `go:generate` directive:

--- a/010_tools/script.sh
+++ b/010_tools/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME
@@ -36,8 +13,8 @@ git config --global advice.detachedHead false
 git config --global push.default current
 
 # block: setup
-mkdir /tmp/go-modules-by-example-tools
-cd /tmp/go-modules-by-example-tools
+mkdir /tmp/tools
+cd /tmp/tools
 go mod init example.com/blah/painkiller
 
 # block: set bin target

--- a/012_modvendor/script.sh
+++ b/012_modvendor/script.sh
@@ -1,28 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-set -x
-
-assert()
-{
-  E_PARAM_ERR=98
-  E_ASSERT_FAILED=99
-
-  if [ -z "$2" ]
-  then
-    exit $E_PARAM_ERR
-  fi
-
-  lineno=$2
-
-  if [ ! $1 ]
-  then
-    echo "Assertion failed:  \"$1\""
-    echo "File \"$0\", line $lineno"
-    exit $E_ASSERT_FAILED
-  fi
-}
-
 # **START**
 
 export GOPATH=$HOME

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 _Go modules by example_ is a series of work-along guides that look to help explain how go modules works and how to get things done.
 
-* [The go modules tour](https://github.com/myitcv/go-modules-by-example/blob/master/001_go_modules_tour/README.md) (a rewrite of the original vgo tour)
-* [Using go modules with gopkg.in](https://github.com/myitcv/go-modules-by-example/blob/master/002_using_gopkg_in/README.md)
-* [Migrating Buffalo from dep to go modules](https://github.com/myitcv/go-modules-by-example/blob/master/003_migrate_buffalo/README.md)
-* [Using a package that has not been converted to go modules](https://github.com/myitcv/go-modules-by-example/blob/master/004_echo_example/README.md)
-* [Example of backwards compatability in Go 1.10 with semantic import paths](https://github.com/myitcv/go-modules-by-example/blob/master/005_old_go/README.md)
-* [Another example of package/project that has not yet been converted to a module](https://github.com/myitcv/go-modules-by-example/blob/master/006_not_yet_go_module/README.md)
-* [Forking a project which has not yet been converted to a Go module](https://github.com/myitcv/go-modules-by-example/blob/master/007_old_code_replace/README.md)
-* [Using modules to generate a vendor](https://github.com/myitcv/go-modules-by-example/blob/master/008_vendor_example/README.md)
-* [How to use submodules](https://github.com/myitcv/go-modules-by-example/blob/master/009_submodules/README.md)
-* [Tools as dependencies](https://github.com/myitcv/go-modules-by-example/blob/master/010_tools/README.md)
-* [Creating a module download cache "vendor"](https://github.com/myitcv/go-modules-by-example/blob/master/012_modvendor/README.md)
+* [The go modules tour](https://github.com/go-modules-by-example/index/blob/master/001_go_modules_tour/README.md) (a rewrite of the original vgo tour)
+* [Using go modules with gopkg.in](https://github.com/go-modules-by-example/index/blob/master/002_using_gopkg_in/README.md)
+* [Migrating Buffalo from dep to go modules](https://github.com/go-modules-by-example/index/blob/master/003_migrate_buffalo/README.md)
+* [Using a package that has not been converted to go modules](https://github.com/go-modules-by-example/index/blob/master/004_echo_example/README.md)
+* [Example of backwards compatability in Go 1.10 with semantic import paths](https://github.com/go-modules-by-example/index/blob/master/005_old_go/README.md)
+* [Another example of package/project that has not yet been converted to a module](https://github.com/go-modules-by-example/index/blob/master/006_not_yet_go_module/README.md)
+* [Forking a project which has not yet been converted to a Go module](https://github.com/go-modules-by-example/index/blob/master/007_old_code_replace/README.md)
+* [Using modules to generate a vendor](https://github.com/go-modules-by-example/index/blob/master/008_vendor_example/README.md)
+* [How to use submodules](https://github.com/go-modules-by-example/index/blob/master/009_submodules/README.md)
+* [Tools as dependencies](https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md)
+* [Creating a module download cache "vendor"](https://github.com/go-modules-by-example/index/blob/master/012_modvendor/README.md)
 * ...
 
-See the [Feedback and TODO wiki](https://github.com/myitcv/go-modules-by-example/wiki/Feedback-TODO) for more up-to-date
+See the [Feedback and TODO wiki](https://github.com/go-modules-by-example/index/wiki/Feedback-TODO) for more up-to-date
 commentary.
 
 ### Structure
@@ -64,8 +64,8 @@ include the commands themselves and/or their output, e.g.:
     {{PrintBlock "install tools" -}}
     ```
 
-Look at the raw [Go modules by example tour README.md](https://raw.githubusercontent.com/myitcv/go-modules-by-example/master/001_go_modules_tour/README.md)
-and [corresponding script](https://github.com/myitcv/go-modules-by-example/blob/master/001_go_modules_tour/script.sh) for more examples.
+Look at the raw [Go modules by example tour README.md](https://raw.githubusercontent.com/go-modules-by-example/index/master/001_go_modules_tour/README.md)
+and [corresponding script](https://github.com/go-modules-by-example/index/blob/master/001_go_modules_tour/script.sh) for more examples.
 
 ### Testing scripts
 
@@ -82,11 +82,13 @@ docker pull golang
 ```
 <!-- END -->
 
-The following two environment variables must be set:
+The following environment variables must be set:
 
 ```bash
-GITHUB_USERNAME # your Github username
-GITHUB_PAT      # a personal access token with public_repo scope
+GITHUB_USERNAME    # your Github username
+GITHUB_PAT         # a personal access token with public_repo scope
+GITHUB_ORG         # an org/user account where forks, examples will be created
+GITHUB_ORG_ARCHIVE # an org/user account where old forks, examples etc will be moved
 ```
 
 _[Create a new personal access token](https://github.com/settings/tokens/new)._

--- a/cmd/egrunner/main.go
+++ b/cmd/egrunner/main.go
@@ -288,11 +288,7 @@ assert()
 		return errorf("failed to write to temp file %v: %v", tfn, err)
 	}
 
-	user := os.Getenv("GITHUB_USERNAME")
-	pat := os.Getenv("GITHUB_PAT")
-	vgoversion := os.Getenv("VGO_VERSION")
-
-	args := []string{"docker", "run", "--rm", "-w", "/root", "-e", "GITHUB_PAT=" + pat, "-e", "GITHUB_USERNAME=" + user, "-e", "VGO_VERSION=" + vgoversion, "--entrypoint", "bash", "-v", "/home/myitcv/.gostuff/1.11/pkg/mod/cache/download/:/cache/", "-v", fmt.Sprintf("%v:/go/bin/%v", ghcli, commgithubcli), "-v", fmt.Sprintf("%v:/%v", tfn, scriptName)}
+	args := []string{"docker", "run", "--rm", "-w", "/root", "-e", "GITHUB_PAT", "-e", "GITHUB_USERNAME", "-e", "VGO_VERSION", "-e", "GITHUB_ORG", "-e", "GITHUB_ORG_ARCHIVE", "--entrypoint", "bash", "-v", "/home/myitcv/.gostuff/1.11/pkg/mod/cache/download/:/cache/", "-v", fmt.Sprintf("%v:/go/bin/%v", ghcli, commgithubcli), "-v", fmt.Sprintf("%v:/%v", tfn, scriptName)}
 
 	if *fGoRoot != "" {
 		args = append(args, "-v", fmt.Sprintf("%v:/go", *fGoRoot))


### PR DESCRIPTION
* Remove cruft from the top of script files (which gets automatically added by `egrunner`)
* Use `GITHUB_ORG` (and `GITHUB_ORG_ARCHIVE`) for the location of forks, examples etc (and old versions of forks, examples etc)
* Updated `githubcli` to learn about repository transfers
* Complete move to https://github.com/go-modules-by-example/index