### PR TITLE
general: use sane default settings for org repos

### DIFF
--- a/001_go_modules_tour/README.md
+++ b/001_go_modules_tour/README.md
@@ -469,7 +469,7 @@ created:
 ```
 $ go test github.com/you/hello rsc.io/quote
 ?   	github.com/you/hello	[no test files]
-ok  	rsc.io/quote	0.002s
+ok  	rsc.io/quote	0.003s
 ```
 
 In the original go command, the package pattern all meant all packages found in
@@ -734,7 +734,7 @@ fork github.com/rsc/quote and then push your change to your fork.
 $ cd ../quote
 $ git remote add $GITHUB_ORG https://github.com/$GITHUB_ORG/quote-fork
 $ git commit -a -m 'my fork'
-[my_quote 1f15b3d] my fork
+[my_quote a681947] my fork
  1 file changed, 1 insertion(+), 1 deletion(-)
 $ git push -q $GITHUB_ORG
 remote: 

--- a/003_migrate_buffalo/README.md
+++ b/003_migrate_buffalo/README.md
@@ -121,38 +121,38 @@ $ go get .
 $ go install -tags sqlite
 $ dep ensure
 $ go test -tags sqlite ./...
-ok  	github.com/gobuffalo/buffalo	0.250s
-ok  	github.com/gobuffalo/buffalo/binding	0.138s
+ok  	github.com/gobuffalo/buffalo	0.271s
+ok  	github.com/gobuffalo/buffalo/binding	0.134s
 ?   	github.com/gobuffalo/buffalo/buffalo	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/build	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/destroy	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/generate	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/updater	[no test files]
-ok  	github.com/gobuffalo/buffalo/generators	0.049s
-ok  	github.com/gobuffalo/buffalo/generators/action	0.063s [no tests to run]
+ok  	github.com/gobuffalo/buffalo/generators	0.079s
+ok  	github.com/gobuffalo/buffalo/generators/action	0.015s [no tests to run]
 ?   	github.com/gobuffalo/buffalo/generators/assets	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/assets/standard	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/assets/webpack	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/docker	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/grift	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/mail	[no test files]
-ok  	github.com/gobuffalo/buffalo/generators/newapp	0.034s
+ok  	github.com/gobuffalo/buffalo/generators/newapp	0.093s
 ?   	github.com/gobuffalo/buffalo/generators/refresh	[no test files]
-ok  	github.com/gobuffalo/buffalo/generators/resource	0.063s
+ok  	github.com/gobuffalo/buffalo/generators/resource	0.041s
 ?   	github.com/gobuffalo/buffalo/generators/soda	[no test files]
 ?   	github.com/gobuffalo/buffalo/grifts	[no test files]
-ok  	github.com/gobuffalo/buffalo/mail	0.066s
+ok  	github.com/gobuffalo/buffalo/mail	0.035s
 ?   	github.com/gobuffalo/buffalo/meta	[no test files]
-ok  	github.com/gobuffalo/buffalo/middleware	0.286s
-ok  	github.com/gobuffalo/buffalo/middleware/basicauth	0.114s
-ok  	github.com/gobuffalo/buffalo/middleware/csrf	0.107s
-ok  	github.com/gobuffalo/buffalo/middleware/i18n	0.139s
+ok  	github.com/gobuffalo/buffalo/middleware	0.167s
+ok  	github.com/gobuffalo/buffalo/middleware/basicauth	0.101s
+ok  	github.com/gobuffalo/buffalo/middleware/csrf	0.088s
+ok  	github.com/gobuffalo/buffalo/middleware/i18n	0.128s
 ?   	github.com/gobuffalo/buffalo/middleware/ssl	[no test files]
-ok  	github.com/gobuffalo/buffalo/middleware/tokenauth	0.089s
+ok  	github.com/gobuffalo/buffalo/middleware/tokenauth	0.074s
 ?   	github.com/gobuffalo/buffalo/plugins	[no test files]
-ok  	github.com/gobuffalo/buffalo/render	0.062s
-ok  	github.com/gobuffalo/buffalo/worker	0.017s
+ok  	github.com/gobuffalo/buffalo/render	0.066s
+ok  	github.com/gobuffalo/buffalo/worker	0.014s
 ```
 
 Now use go build (or any other go command) to turn dep's Gopkg.lock into a populated go.mod file:
@@ -162,10 +162,10 @@ $ go build -tags sqlite
 go: creating new go.mod: module github.com/gobuffalo/buffalo
 go: copying requirements from Gopkg.lock
 go: finding github.com/gobuffalo/packr v1.13.7
+go: finding github.com/gorilla/sessions v1.1.3
 go: finding github.com/davecgh/go-spew v1.1.1
 go: finding github.com/gobuffalo/pop v4.8.3+incompatible
 go: finding github.com/markbates/refresh v1.4.10
-go: finding github.com/gobuffalo/genny v0.0.0-20181007153042-b8de7d566757
 ...
 $ cat go.mod
 module github.com/gobuffalo/buffalo
@@ -182,53 +182,53 @@ Run tests to see that baseline behaviour hasn't changed:
 
 ```
 $ go test -tags sqlite ./...
-go: downloading github.com/dgrijalva/jwt-go v3.2.0+incompatible
-go: downloading github.com/markbates/willie v1.0.9
-go: downloading github.com/markbates/deplist v1.0.5
-go: downloading github.com/unrolled/secure v0.0.0-20181005190816-ff9db2ff917f
 go: downloading github.com/spf13/cobra v0.0.3
-go: downloading gopkg.in/mail.v2 v2.0.0-20180731213649-a0242b2233b4
-go: downloading github.com/stretchr/testify v1.2.2
-go: downloading github.com/markbates/hmax v1.0.0
 go: downloading github.com/nicksnyder/go-i18n v1.10.0
+go: downloading github.com/unrolled/secure v0.0.0-20181005190816-ff9db2ff917f
+go: downloading github.com/markbates/deplist v1.0.5
+go: downloading github.com/markbates/willie v1.0.9
+go: downloading github.com/dgrijalva/jwt-go v3.2.0+incompatible
+go: downloading gopkg.in/mail.v2 v2.0.0-20180731213649-a0242b2233b4
+go: downloading golang.org/x/tools v0.0.0-20181010000725-29f11e2b93f4
+go: downloading github.com/markbates/hmax v1.0.0
 go: downloading github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f
-go: downloading golang.org/x/tools v0.0.0-20181008205924-a2b3f7f249e9
-go: downloading github.com/spf13/pflag v1.0.3
+go: downloading github.com/stretchr/testify v1.2.2
 go: downloading github.com/pelletier/go-toml v1.2.0
+go: downloading github.com/spf13/pflag v1.0.3
 go: downloading github.com/pmezard/go-difflib v1.0.0
 go: downloading github.com/davecgh/go-spew v1.1.1
-ok  	github.com/gobuffalo/buffalo	0.277s
-ok  	github.com/gobuffalo/buffalo/binding	0.187s
+ok  	github.com/gobuffalo/buffalo	0.324s
+ok  	github.com/gobuffalo/buffalo/binding	0.088s
 ?   	github.com/gobuffalo/buffalo/buffalo	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/build	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/destroy	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/generate	[no test files]
 ?   	github.com/gobuffalo/buffalo/buffalo/cmd/updater	[no test files]
-ok  	github.com/gobuffalo/buffalo/generators	0.092s
-ok  	github.com/gobuffalo/buffalo/generators/action	0.086s [no tests to run]
+ok  	github.com/gobuffalo/buffalo/generators	0.121s
+ok  	github.com/gobuffalo/buffalo/generators/action	0.080s [no tests to run]
 ?   	github.com/gobuffalo/buffalo/generators/assets	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/assets/standard	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/assets/webpack	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/docker	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/grift	[no test files]
 ?   	github.com/gobuffalo/buffalo/generators/mail	[no test files]
-ok  	github.com/gobuffalo/buffalo/generators/newapp	0.057s
+ok  	github.com/gobuffalo/buffalo/generators/newapp	0.154s
 ?   	github.com/gobuffalo/buffalo/generators/refresh	[no test files]
-ok  	github.com/gobuffalo/buffalo/generators/resource	0.079s
+ok  	github.com/gobuffalo/buffalo/generators/resource	0.201s
 ?   	github.com/gobuffalo/buffalo/generators/soda	[no test files]
 ?   	github.com/gobuffalo/buffalo/grifts	[no test files]
-ok  	github.com/gobuffalo/buffalo/mail	0.080s
+ok  	github.com/gobuffalo/buffalo/mail	0.062s
 ?   	github.com/gobuffalo/buffalo/meta	[no test files]
-ok  	github.com/gobuffalo/buffalo/middleware	0.330s
-ok  	github.com/gobuffalo/buffalo/middleware/basicauth	0.116s
-ok  	github.com/gobuffalo/buffalo/middleware/csrf	0.092s
-ok  	github.com/gobuffalo/buffalo/middleware/i18n	0.086s
+ok  	github.com/gobuffalo/buffalo/middleware	0.248s
+ok  	github.com/gobuffalo/buffalo/middleware/basicauth	0.118s
+ok  	github.com/gobuffalo/buffalo/middleware/csrf	0.100s
+ok  	github.com/gobuffalo/buffalo/middleware/i18n	0.068s
 ?   	github.com/gobuffalo/buffalo/middleware/ssl	[no test files]
-ok  	github.com/gobuffalo/buffalo/middleware/tokenauth	0.077s
+ok  	github.com/gobuffalo/buffalo/middleware/tokenauth	0.091s
 ?   	github.com/gobuffalo/buffalo/plugins	[no test files]
-ok  	github.com/gobuffalo/buffalo/render	0.063s
-ok  	github.com/gobuffalo/buffalo/worker	0.017s
+ok  	github.com/gobuffalo/buffalo/render	0.058s
+ok  	github.com/gobuffalo/buffalo/worker	0.019s
 ```
 
 At this point we would now git add go.mod and git commit.

--- a/004_echo_example/README.md
+++ b/004_echo_example/README.md
@@ -128,19 +128,19 @@ Now, we explicitly add `github.com/labstack/echo@v3.2.1` as a requirement:
 $ go get github.com/labstack/echo@v3.2.1
 go: finding github.com/labstack/echo v3.2.1
 go: downloading github.com/labstack/echo v3.2.1+incompatible
-go: finding github.com/labstack/gommon/color latest
 go: finding github.com/labstack/gommon/log latest
+go: finding github.com/labstack/gommon/color latest
 go: finding golang.org/x/crypto/acme/autocert latest
 go: finding golang.org/x/crypto/acme latest
 go: finding golang.org/x/crypto latest
-go: downloading golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4
+go: downloading golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941
 go: finding github.com/labstack/gommon v0.2.7
 go: downloading github.com/labstack/gommon v0.2.7
+go: finding github.com/valyala/fasttemplate latest
 go: finding github.com/mattn/go-colorable v0.0.9
 go: finding github.com/mattn/go-isatty v0.0.4
-go: finding github.com/valyala/fasttemplate latest
-go: downloading github.com/mattn/go-colorable v0.0.9
 go: downloading github.com/mattn/go-isatty v0.0.4
+go: downloading github.com/mattn/go-colorable v0.0.9
 go: downloading github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4
 go: finding github.com/valyala/bytebufferpool v1.0.0
 go: downloading github.com/valyala/bytebufferpool v1.0.0
@@ -166,7 +166,7 @@ require (
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
-	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 // indirect
+	golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941 // indirect
 )
 ```
 

--- a/005_old_go/README.md
+++ b/005_old_go/README.md
@@ -90,7 +90,7 @@ $ git init
 Initialized empty Git repository in /root/hello/.git/
 $ git add -A
 $ git commit -m 'Initial commit'
-[master (root-commit) 8dd2bd1] Initial commit
+[master (root-commit) 46727f3] Initial commit
  3 files changed, 9 insertions(+)
  create mode 100644 go.mod
  create mode 100644 goodbye/goodbye.go

--- a/010_tools/README.md
+++ b/010_tools/README.md
@@ -121,7 +121,7 @@ $ go install golang.org/x/tools/cmd/stringer
 go: finding golang.org/x/tools/cmd/stringer latest
 go: finding golang.org/x/tools/cmd latest
 go: finding golang.org/x/tools latest
-go: downloading golang.org/x/tools v0.0.0-20181008205924-a2b3f7f249e9
+go: downloading golang.org/x/tools v0.0.0-20181010000725-29f11e2b93f4
 ```
 
 The module reflects the dependency:
@@ -135,7 +135,7 @@ $ go mod edit -json
 	"Require": [
 		{
 			"Path": "golang.org/x/tools",
-			"Version": "v0.0.0-20181008205924-a2b3f7f249e9",
+			"Version": "v0.0.0-20181010000725-29f11e2b93f4",
 			"Indirect": true
 		}
 	],

--- a/011_using_gohack/README.md
+++ b/011_using_gohack/README.md
@@ -102,8 +102,8 @@ go: finding gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 go: finding github.com/kr/text v0.1.0
 go: finding github.com/kr/pty v1.1.1
 go: downloading github.com/rogpeppe/go-internal v1.0.0-alpha
-go: downloading golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e
 go: downloading gopkg.in/errgo.v2 v2.1.0
+go: downloading golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e
 $ gohack help
 The gohack command checks out Go module dependencies
 into a directory where they can be edited, and adjusts

--- a/013_cyclic/README.md
+++ b/013_cyclic/README.md
@@ -119,11 +119,11 @@ $ go test -v ./...
 Here is A: B
 --- PASS: TestUsingA (0.00s)
 PASS
-ok  	github.com/go-modules-by-example/cyclic/b	0.002s
+ok  	github.com/go-modules-by-example/cyclic/b	0.003s
 $ git add -A
 $ git commit -q -am "Commit 1: initial commit of parent module github.com/$GITHUB_ORG/cyclic"
 $ git rev-parse HEAD
-d1d904025716fb4998b1ab77d713843cc9744839
+e6225575470d3df28c368534ec649dc085de8f49
 $ git push -q
 remote: 
 remote: Create a pull request for 'master' on GitHub by visiting:        
@@ -148,7 +148,7 @@ $ cd ..
 $ git add -A
 $ git commit -q -am "Commit 2: create github.com/$GITHUB_ORG/cyclic/b"
 $ git rev-parse HEAD
-0de870e490e2e6b71958895a03b8439f08eb8fed
+142b4e87b00ca18b19aaad2b35c4e9c8df3c1d8b
 $ git push -q
 ```
 
@@ -157,13 +157,13 @@ Until #26241 is merged, this is where the mutual dependency gets created:
 ```
 $ go test -v ./...
 go: finding github.com/go-modules-by-example/cyclic/b latest
-go: downloading github.com/go-modules-by-example/cyclic/b v0.0.0-20181009115017-0de870e490e2
+go: downloading github.com/go-modules-by-example/cyclic/b v0.0.0-20181010093657-142b4e87b00c
 ?   	github.com/go-modules-by-example/cyclic/a	[no test files]
 $ cd b
 $ go test -v ./...
 go: finding github.com/go-modules-by-example/cyclic/a latest
 go: finding github.com/go-modules-by-example/cyclic latest
-go: downloading github.com/go-modules-by-example/cyclic v0.0.0-20181009115017-0de870e490e2
+go: downloading github.com/go-modules-by-example/cyclic v0.0.0-20181010093657-142b4e87b00c
 === RUN   TestUsingA
 Here is A: B
 --- PASS: TestUsingA (0.00s)
@@ -178,7 +178,7 @@ List the dependencies of `github.com/go-modules-by-example/cyclic
 $ cd ..
 $ go list -m all
 github.com/go-modules-by-example/cyclic
-github.com/go-modules-by-example/cyclic/b v0.0.0-20181009115017-0de870e490e2
+github.com/go-modules-by-example/cyclic/b v0.0.0-20181010093657-142b4e87b00c
 ```
 
 List the dependencies of `github.com/go-modules-by-example/cyclic/b
@@ -188,7 +188,7 @@ List the dependencies of `github.com/go-modules-by-example/cyclic/b
 $ cd b
 $ go list -m all
 github.com/go-modules-by-example/cyclic/b
-github.com/go-modules-by-example/cyclic v0.0.0-20181009115017-0de870e490e2
+github.com/go-modules-by-example/cyclic v0.0.0-20181010093657-142b4e87b00c
 ```
 
 Commit the mutual dependency:
@@ -198,7 +198,7 @@ $ cd ..
 $ git add -A
 $ git commit -q -am "Commit 3: the mutual dependency"
 $ git rev-parse HEAD
-bf3bfb1af3e82e4dcea570615376d821a96b594b
+8cca9bce1e0750660c176fb763c23252750cf51c
 $ git push -q
 ```
 

--- a/cmd/githubcli/main.go
+++ b/cmd/githubcli/main.go
@@ -122,7 +122,12 @@ func main() {
 		nameParts := strings.Split(args[0], "/")
 
 		r := &github.Repository{
-			Name: &nameParts[len(nameParts)-1],
+			Name:        &nameParts[len(nameParts)-1],
+			HasWiki:     github.Bool(false),
+			HasIssues:   github.Bool(false),
+			HasProjects: github.Bool(false),
+			Description: github.String("Part of Go Modules By Example"),
+			Homepage:    github.String("https://github.com/go-modules-by-example/index"),
 		}
 
 		// when creating a repo, we set userOrOrg to "" to indicate a


### PR DESCRIPTION
When creating example repos alongside index, we want them to effecitvely
be read-only. So we set default permissions of "no issues", "no wiki"
etc.